### PR TITLE
Fixing Diff URL

### DIFF
--- a/src/smart_scan.py
+++ b/src/smart_scan.py
@@ -53,8 +53,7 @@ def main():
     logging.info("Retrieving diff from GitHub")
     gh_client = github.API(gh_ctx.vars["gh_token"])
     try:
-        print(gh_ctx.html_url)
-        diff = gh_client.get_diff(gh_ctx.html_url)
+        diff = gh_client.get_diff(gh_ctx.url)
     except Exception as e:
         logging.error(e)
         set_action_output("yes")

--- a/src/smart_scan.py
+++ b/src/smart_scan.py
@@ -53,8 +53,8 @@ def main():
     logging.info("Retrieving diff from GitHub")
     gh_client = github.API(gh_ctx.vars["gh_token"])
     try:
-        print(gh_ctx.diff_url)
-        diff = gh_client.get_diff(gh_ctx.diff_url)
+        print(gh_ctx.html_url)
+        diff = gh_client.get_diff(gh_ctx.html_url)
     except Exception as e:
         logging.error(e)
         set_action_output("yes")

--- a/src/smart_scan.py
+++ b/src/smart_scan.py
@@ -53,6 +53,7 @@ def main():
     logging.info("Retrieving diff from GitHub")
     gh_client = github.API(gh_ctx.vars["gh_token"])
     try:
+        print(gh_ctx.diff_url)
         diff = gh_client.get_diff(gh_ctx.diff_url)
     except Exception as e:
         logging.error(e)

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -59,6 +59,9 @@ class EventContext:
         Returns:
             dict: A dictionary containing the input variables set by the action.
         """
+        # print all env vars
+        for key, value in os.environ.items():
+            print(f"{key}: {value}")
         input_vars = {
             "gh_token": os.environ.get("INPUT_GH_TOKEN"),
             "model": os.environ.get("INPUT_MODEL"),

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -37,7 +37,7 @@ class EventContext:
         action = data.get("action")
         if action in ["synchronize", "opened"]:
             self.action = action
-            self.diff_url = data["pull_request"]["diff_url"]
+            self.html_url = data["pull_request"]["html_url"]
             self.comment_url = data["pull_request"]["comments_url"]
         else:
             self.action = None

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -38,7 +38,7 @@ class EventContext:
         action = data.get("action")
         if action in ["synchronize", "opened"]:
             self.action = action
-            self.html_url = data["pull_request"]["html_url"]
+            self.html_url = data["pull_request"]["url"]
             self.comment_url = data["pull_request"]["comments_url"]
         else:
             self.action = None

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -30,6 +30,7 @@ class EventContext:
             with open("/github/workflow/event.json", "r") as file:
                 contents = file.read()
                 data = json.loads(contents)
+                print(data)
         except FileNotFoundError:
             raise Exception("Could not find event.json.  Are you running this locally?")
 
@@ -117,7 +118,7 @@ class API:
             "Accept": "application/vnd.github.v3.diff",
             "Content-Type": "application/json",
         }
-        
+
     def get_diff(self, compare_url):
         """
         Calls the GitHub API to retrieve a diff.

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -30,7 +30,6 @@ class EventContext:
             with open("/github/workflow/event.json", "r") as file:
                 contents = file.read()
                 data = json.loads(contents)
-                print(data)
         except FileNotFoundError:
             raise Exception("Could not find event.json.  Are you running this locally?")
 
@@ -59,9 +58,6 @@ class EventContext:
         Returns:
             dict: A dictionary containing the input variables set by the action.
         """
-        # print all env vars
-        for key, value in os.environ.items():
-            print(f"{key}: {value}")
         input_vars = {
             "gh_token": os.environ.get("INPUT_GH_TOKEN"),
             "model": os.environ.get("INPUT_MODEL"),

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -129,6 +129,9 @@ class API:
             str: The diff for the specified commit range.
         """
         response = requests.get(compare_url, headers=self.diff_headers)
+        print(response.status_code)
+        print(response.text)
+        print(compare_url)
         if response.status_code == 200:
             logging.info("Successfully retrieved diff")
             return response.text

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -30,7 +30,6 @@ class EventContext:
             with open("/github/workflow/event.json", "r") as file:
                 contents = file.read()
                 data = json.loads(contents)
-                print(json.dumps(data, indent=4))
         except FileNotFoundError:
             raise Exception("Could not find event.json.  Are you running this locally?")
 
@@ -38,7 +37,7 @@ class EventContext:
         action = data.get("action")
         if action in ["synchronize", "opened"]:
             self.action = action
-            self.html_url = data["pull_request"]["url"]
+            self.url = data["pull_request"]["url"]
             self.comment_url = data["pull_request"]["comments_url"]
         else:
             self.action = None
@@ -130,9 +129,6 @@ class API:
             str: The diff for the specified commit range.
         """
         response = requests.get(compare_url, headers=self.diff_headers)
-        print(response.status_code)
-        print(response.text)
-        print(compare_url)
         if response.status_code == 200:
             logging.info("Successfully retrieved diff")
             return response.text

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -30,6 +30,7 @@ class EventContext:
             with open("/github/workflow/event.json", "r") as file:
                 contents = file.read()
                 data = json.loads(contents)
+                print(json.dumps(data, indent=4))
         except FileNotFoundError:
             raise Exception("Could not find event.json.  Are you running this locally?")
 

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -112,7 +112,12 @@ class API:
             "Accept": "application/vnd.github.v3+json",
             "Content-Type": "application/json",
         }
-
+        self.diff_headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github.v3.diff",
+            "Content-Type": "application/json",
+        }
+        
     def get_diff(self, compare_url):
         """
         Calls the GitHub API to retrieve a diff.
@@ -123,7 +128,7 @@ class API:
         Returns:
             str: The diff for the specified commit range.
         """
-        response = requests.get(compare_url, headers=self.headers)
+        response = requests.get(compare_url, headers=self.diff_headers)
         if response.status_code == 200:
             logging.info("Successfully retrieved diff")
             return response.text

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -10,15 +10,15 @@ sys.path.append(f"{os.path.dirname(os.path.dirname(os.path.abspath(__file__)))}/
 
 class TestEventContext(unittest.TestCase):
     def setUp(self):
-        with patch("builtins.open", mock_open(read_data='{"action": "synchronize", "pull_request": {"diff_url": "test_diff_url", "comments_url": "test_comment_url"}}')):
+        with patch("builtins.open", mock_open(read_data='{"action": "synchronize", "pull_request": {"url": "test_url", "comments_url": "test_comment_url"}}')):
             self.context = EventContext()
 
-    @patch("builtins.open", mock_open(read_data='{"action": "synchronize", "pull_request": {"diff_url": "test_diff_url", "comments_url": "test_comment_url"}}'))
+    @patch("builtins.open", mock_open(read_data='{"action": "synchronize", "pull_request": {"url": "test_url", "comments_url": "test_comment_url"}}'))
     def test_get_action_context_pull_request(self):
         self.context._EventContext__get_action_context()
 
         self.assertEqual(self.context.action, "synchronize")
-        self.assertEqual(self.context.diff_url, "test_diff_url")
+        self.assertEqual(self.context.url, "test_url")
         self.assertEqual(self.context.comment_url, "test_comment_url")
 
     @patch("builtins.open", mock_open(read_data='{"compare": "test_compare_url"}'))
@@ -27,7 +27,7 @@ class TestEventContext(unittest.TestCase):
 
         self.assertEqual(self.context.action, None)
 
-    @patch("builtins.open", mock_open(read_data='{"action": "labeled", "pull_request": {"diff_url": "test_diff_url", "comments_url": "test_comment_url"}}'))
+    @patch("builtins.open", mock_open(read_data='{"action": "labeled", "pull_request": {"url": "test_url", "comments_url": "test_comment_url"}}'))
     def test_get_action_context_label(self):
         self.context._EventContext__get_action_context()
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -125,7 +125,7 @@ class TestAPI(unittest.TestCase):
         diff = self.api.get_diff(compare_url)
 
         self.assertEqual(diff, "test_diff")
-        mock_get.assert_called_once_with(compare_url, headers=self.api.headers)
+        mock_get.assert_called_once_with(compare_url, headers=self.api.diff_headers)
 
     @patch("requests.get")
     def test_get_diff_failure(self, mock_get):
@@ -139,7 +139,7 @@ class TestAPI(unittest.TestCase):
         with self.assertRaises(Exception):
             self.api.get_diff(compare_url)
 
-        mock_get.assert_called_once_with(compare_url, headers=self.api.headers)
+        mock_get.assert_called_once_with(compare_url, headers=self.api.diff_headers)
 
     @patch("requests.post")
     def test_add_comment_success(self, mock_post):


### PR DESCRIPTION
The original diff URL was not working properly with private repos.  In this change we are pointing to the correct API endpoint now.